### PR TITLE
Adding support for Tools uninstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-dashboard",
-  "version": "1.1.4",
+  "version": "master",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-dashboard",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-dashboard",
-  "version": "master",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/api.js
+++ b/src/api.js
@@ -371,6 +371,10 @@ export default {
         .then(res => {
           return res.data.filter(tool => tool.id == id)[0]
         })
+    },
+    delete(id) {
+      return api.delete('/tools/' + id)
+        .then(res => res.data)
     }
   },
 

--- a/src/pages/servers/tools/index.vue
+++ b/src/pages/servers/tools/index.vue
@@ -52,6 +52,11 @@ export default {
         return
       }
 
+      if (tool.status == 'uninstalling') {
+        this.$notify.info('Tool uninstalling', 'This tool is still unstalling. Please wait.')
+        return
+      }
+
       this.$router.push({ name: 'servers.tools.show', params: { 
         serverID: this.server.id, toolName: tool.name
       }})
@@ -135,7 +140,7 @@ export default {
           statusString = 'Installing'
           statusClass = 'loading'
           break
-        case 'deleting':
+        case 'uninstalling':
           statusString = 'Uninstalling'
           statusClass = 'loading'
           break
@@ -153,7 +158,7 @@ export default {
     },
     needsReloading() {
       return this.serverToolsRaw.filter(serverTool => {
-        return serverTool.status != 'installed'
+        return serverTool.status != 'installed' || serverTool.status != "uninstalling"
       }).length > 0
     }
   },

--- a/src/pages/servers/tools/show.vue
+++ b/src/pages/servers/tools/show.vue
@@ -6,7 +6,7 @@
         div(v-if="serverTool.status == 'installed'")
           p Version #[code {{ versionString(tool.version) }}] is currently installed.
           div.buttons
-            vr-button(color="danger") Uninstall
+            vr-button(color="danger" @action="uninstall") Uninstall
         div(v-else)
           p Version #[code {{ versionString(tool.version) }}] is currently installing. Please wait.
       div(v-else)
@@ -53,6 +53,17 @@ export default {
         toolID: this.installToolID
       })
       this.$notify.info('Installing ' + this.toolName.readable(), 'Please wait while the tool installs.')
+      this.$router.push({ name: 'servers.tools.index' })
+    },
+    async uninstall() {
+      var question = `Are you sure you want to delete the Tool: '${this.toolName.readable()}'`
+      var answer = confirm(question)
+      if (!answer) {
+        return
+      }
+      await this.$api.tools.delete(this.serverTool.id)
+
+      this.$notify.info('Uninstalling ' + this.toolName.readable(), 'Please wait while the tool uninstalls.')
       this.$router.push({ name: 'servers.tools.index' })
     },
     versionString(version) {


### PR DESCRIPTION
This adds support for uninstalling tools.

This requires deploy of recent api master branch. Which makes some changes to the uninstall, and adds support for Swift 5.0.2